### PR TITLE
Integración con Coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,6 @@ before_script:
 
 script:
   ./gradlew build
+  
+after_success:
+  - ./gradlew jacocoTestReport coveralls

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ SeviBus
 
 SeviBus - version 4 (under development) - Now with Open Source! :D
 
-[![Build Status](https://travis-ci.org/Sloy/SeviBus.svg?branch=master)](https://travis-ci.org/Sloy/SeviBus)
+[![Build Status](https://travis-ci.org/Sloy/SeviBus.svg?branch=master)](https://travis-ci.org/Sloy/SeviBus)  [![Coverage Status](https://coveralls.io/repos/Sloy/SeviBus/badge.svg)](https://coveralls.io/r/Sloy/SeviBus)

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -4,11 +4,14 @@ buildscript {
     }
     dependencies {
         classpath 'me.tatarka:gradle-retrolambda:2.4.1'
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.0.1'
     }
 }
 
 apply plugin: 'java'
 apply plugin: 'retrolambda'
+apply plugin: 'jacoco'
+apply plugin: 'com.github.kt3k.coveralls'
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
@@ -23,4 +26,11 @@ dependencies {
 
 retrolambda {
     javaVersion JavaVersion.VERSION_1_7
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled = true // coveralls plugin depends on xml format report
+        html.enabled = true
+    }
 }

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath 'me.tatarka:gradle-retrolambda:2.4.1'
-        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.0.1'
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.0.1x'
     }
 }
 


### PR DESCRIPTION
Integrado Coveralls para cobertura de tests en el módulo de dominio.

Se debería configurar la cobertura también para los otros dos módulos Android (presentation y data).
Es un buen comienzo.

La cobertura se ejecuta con JaCoCo y se exporta a Coveralls.io en formato xml.
Se puede comprobar en formato html la cobertura de cada paquete y clase si se ejecuta la tarea jacocoTestReport en local.
